### PR TITLE
embassy example: Use `WEB_TASK_POOL_SIZE` as the task pool size directly

### DIFF
--- a/examples/hello_world_embassy/src/main.rs
+++ b/examples/hello_world_embassy/src/main.rs
@@ -81,9 +81,9 @@ impl picoserve::extract::FromRef<AppState> for SharedControl {
 
 type AppRouter = impl picoserve::routing::PathRouter<AppState>;
 
-const WEB_TASK_POOL_SIZE: usize = 8; // MUST match pool_size of web_task below
+const WEB_TASK_POOL_SIZE: usize = 8;
 
-#[embassy_executor::task(pool_size = 8)]
+#[embassy_executor::task(pool_size = WEB_TASK_POOL_SIZE)]
 async fn web_task(
     id: usize,
     stack: &'static embassy_net::Stack<cyw43::NetDriver<'static>>,


### PR DESCRIPTION
This should be possible since https://github.com/embassy-rs/embassy/commit/2809e926cf8a3a1556c674a7b17c8db4b926f243