### PR TITLE
Fix newline in WebSocketKeyHeaderMissing message

### DIFF
--- a/src/response/ws.rs
+++ b/src/response/ws.rs
@@ -44,7 +44,7 @@ impl super::IntoResponse for WebSocketUpgradeRejection {
                     "Websocket version must be 13\n"
                 }
                 WebSocketUpgradeRejection::WebSocketKeyHeaderMissing => {
-                    r#"Websocket upgrade header "sec-websocket-key" missing\n"#
+                    "Websocket upgrades must have a `Sec-WebSocket-Key` header\n"
                 }
             },
         )


### PR DESCRIPTION
The raw string literal was causing the message to be sent with a literal `\n`. I rewrote it as a plain string literal and tried to make it closer to the style of the other messages.

Also, thanks for the library! It's really nice to use; I can almost forget I'm writing for a microcontroller :grinning: 