### PR TITLE
Implement `Content` for `Vec<u8>` and `String` behind `alloc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,8 @@ serde = { version = "1.0.171", default-features = false, features = ["derive"] }
 tokio = { version = "1.32.0", optional = true, features = ["io-util", "net", "time"] }
 
 [features]
-std = []
+std = ["alloc"]
+alloc = []
 tokio = ["dep:tokio", "std", "serde/std"]
 embassy = ["dep:embassy-time", "dep:embassy-net"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@
 #[cfg(all(feature = "tokio", feature = "embassy"))]
 compile_error!("You cannot enable both tokio and embassy support");
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub mod extract;
 pub mod io;
 pub mod request;


### PR DESCRIPTION
This makes it way easier to deal with those types since we don't need to return references to variables owned by the current function.