### PR TITLE
Proposal: Use RST shutdown instead of FIN handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All public type which implement `Debug` also implement `defmt::Format`
   - Logging is done using `defmt`
 
+### Changed
+
+- Changed shutdown of [`embassy_net::tcp::TcpSocket`](https://docs.rs/embassy-net/0.4.0/embassy_net/tcp/struct.TcpSocket.html) to use RST instead of FIN handshake.
+
 ## [0.9.1] - 2024-02-12
 
 ### Added


### PR DESCRIPTION
In the Embassy implementation, when shutting down a socket, I propose to use a forcible RST shutdown instead of a FIN handshake sequence.

**Reason:** In embedded devices, we typically have only a limited number of sockets to serve requests, and we need to free them as soon as we know that everything has been sent to the client.

With the FIN handshake triggered by [`embassy_net::tcp::TcpSocket::close()`](https://docs.embassy.dev/embassy-net/git/default/tcp/struct.TcpSocket.html#method.close), we are essentially forced to wait until the client side not only confirms this request but sends its own FIN message (which we then have to ACK).[^1]

[^1]: https://www.baeldung.com/cs/tcp-fin-vs-rst#fin-message

During my experiments with a Linux client and an STM32 device as server, running a tight `curl`/`wget` loop, this round-trip takes anywhere between 100 and 500 ms. From the client's perspective, the socket has already been shut down and another request may be issued immediately afterwards—while our server-side socket is not yet ready to receive another connection.

With my proposed changes, I can run a tight loop without connection errors, serving a large number of requests back to back from a single server socket. Before the changes, the loop would typically break after the first or second request.

However, I am not sure if that is the right way to go. I tried to lay out more of my reasoning in the code.

PS: Maybe we could also make this configurable, with a third option in `KeepAlive`?