### PR TITLE
Add double-quote to acceptable bytes in header to fix error caused by If-None-Match

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -699,7 +699,7 @@ impl<'b, R: Read> Reader<'b, R> {
                         }
                         b if b.is_ascii_alphanumeric()
                             | b.is_ascii_whitespace()
-                            | b"-_.~!#$&'()*+,/:;=?@[]".contains(&b) => {}
+                            | b"-_.~!\"#$&'()*+,/:;=?@[]".contains(&b) => {}
                         _ => return Err(ReadError::InvalidByteInHeader),
                     }
 


### PR DESCRIPTION
### Issue 
Issue experienced using picoserve 0.10.1 on STM32 platform with embassy.

Any browser HTTP request containing the header "If-None-Match" returned "Invalid Byte in Header". This can be reproduced in Firefox by loading a webpage, and then clicking the refresh button, with caching enabled if Developer Tools is open.

As per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match) the Etag value in the If-None-Match header is contained in double-quotes, inside the Header value.

### Resolution
Adding the double-quote character to the acceptable characters in this check resolves this issue on my platform and browser requests are returned successfully. Please do let me know if there's a better way to fix this.

Thanks for the library!