### PR TITLE
Refactor header parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Refactored header parsing to reject more invalid requests and fix a possible panic (#39)
+
 ## [0.10.3] - 2024-05-06
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,9 +279,6 @@ async fn serve_and_shutdown<State, T: Timer, P: routing::PathRouter<State>, S: i
                             "Invalid Header line: No ':' character"
                         }
                         request::ReadError::InvalidByteInHeader => "Invalid Byte in Header",
-                        request::ReadError::InvalidEscapedCharInHeader => {
-                            "Invalid Escape Character in Header"
-                        }
                         request::ReadError::UnexpectedEof => "Unexpected EOF while reading request",
                         request::ReadError::BufferFull => "Request Header Fields Too Large",
                         request::ReadError::IO(err) => return Err(err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,12 +281,14 @@ async fn serve_and_shutdown<State, T: Timer, P: routing::PathRouter<State>, S: i
                         request::ReadError::InvalidByteInHeader => "Invalid Byte in Header",
                         request::ReadError::UnexpectedEof => "Unexpected EOF while reading request",
                         request::ReadError::BufferFull => "Request Header Fields Too Large",
+                        request::ReadError::NotImplemented => "Not Implemented",
                         request::ReadError::IO(err) => return Err(err),
                     };
                     let code = match err {
                         request::ReadError::BufferFull => {
                             response::StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
                         }
+                        request::ReadError::NotImplemented => response::StatusCode::NOT_IMPLEMENTED,
                         _ => response::StatusCode::BAD_REQUEST,
                     };
 


### PR DESCRIPTION
This changes the header parsing logic, to implement the changes
discussed in #39.  In particular, this no longer attempts to do
percent-decoding, and also does more validation of the header contents
to adhere more closely to RFCs 9110 and 9112.

I did end up replacing the Subslice code with a new ReadHelper class.
This API seems a bit simpler and safer to me since it largely operates
on slices rather than offsets and ranges.  The one case where the
ReadHelper API still feels a bit awkward here is dealing with the any
leftover portion of data after a request that may be from the new
request.  I think this could probably be cleaned up in the future if
desired.  It seems like we would need to refactor this somewhat in the
future anyway if we ever want to support chunked transfer encoding of
POST bodies.

The other reason I added the `ReadHelper` API is because I think it will
make it easier to use `ReadHelper` in the future for other use cases,
like reading headers in a `multipart/form-data` POST body or the
trailers of a chunked `POST` body.