### PR TITLE
request: allow braces in header

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -699,7 +699,7 @@ impl<'b, R: Read> Reader<'b, R> {
                         }
                         b if b.is_ascii_alphanumeric()
                             | b.is_ascii_whitespace()
-                            | b"-_.~!\"#$&'()*+,/:;=?@[]".contains(&b) => {}
+                            | b"-_.~!\"#$&'()*+,/:;=?@[]{}".contains(&b) => {}
                         _ => return Err(ReadError::InvalidByteInHeader),
                     }
 


### PR DESCRIPTION
Use case: For unknown reasons, an android app using [`okhttp`](https://square.github.io/okhttp/) sends `Error: {}` in the HTTP header. I can't see why curly braces would not be allowed. AFAICT braces should be allowed in header field values, see e.g. [RFC9110 5.5](https://www.rfc-editor.org/rfc/rfc9110#section-5.5). They are certainly [common](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) in response field values.