### PR TITLE
Constify methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ impl<D> Config<D> {
     /// Keep the connection alive after the response has been sent, allowing the client to make further requests on the same TCP connection.
     /// This should only be called if multiple sockets are handling HTTP connections to avoid a single client hogging the connection
     /// and preventing other clients from making requests.
-    pub fn keep_connection_alive(mut self) -> Self {
+    pub const fn keep_connection_alive(mut self) -> Self {
         self.connection = KeepAlive::KeepAlive;
 
         self
@@ -162,21 +162,21 @@ impl<D> Config<D> {
 
     /// Close the connection after the response has been sent, i.e. each TCP connection serves a single request.
     /// This is the default, but allows the configuration to be more explicit.
-    pub fn close_connection_after_response(mut self) -> Self {
+    pub const fn close_connection_after_response(mut self) -> Self {
         self.connection = KeepAlive::Close;
 
         self
     }
 
     /// Perform a graceful shutdown after handling all requests, waiting for the client to acknowledge the closure
-    pub fn shutdown_connection_on_close(mut self) -> Self {
+    pub const fn shutdown_connection_on_close(mut self) -> Self {
         self.shutdown_method = ShutdownMethod::Shutdown;
 
         self
     }
 
     /// Abort the connection after handling all requests, without waiting for the client to acknowledge the closure
-    pub fn abort_connection_on_close(mut self) -> Self {
+    pub const fn abort_connection_on_close(mut self) -> Self {
         self.shutdown_method = ShutdownMethod::Abort;
 
         self

--- a/src/request.rs
+++ b/src/request.rs
@@ -387,32 +387,32 @@ pub struct RequestParts<'r> {
 
 impl<'r> RequestParts<'r> {
     /// Return the method as sent by the client
-    pub fn method(&self) -> &'r str {
+    pub const fn method(&self) -> &'r str {
         self.method
     }
 
     /// Return the request path, without the query or fragments
-    pub fn path(&self) -> Path<'r> {
+    pub const fn path(&self) -> Path<'r> {
         self.path
     }
 
     /// Return the query section of the request URL, i.e. everything after the "?"
-    pub fn query(&self) -> Option<UrlEncodedString<'r>> {
+    pub const fn query(&self) -> Option<UrlEncodedString<'r>> {
         self.query
     }
 
     /// Return the fragments of the request URL, i.e. everything after the "#"
-    pub fn fragments(&self) -> Option<UrlEncodedString<'r>> {
+    pub const fn fragments(&self) -> Option<UrlEncodedString<'r>> {
         self.fragments
     }
 
     /// Return the HTTP version as sent by the client
-    pub fn http_version(&self) -> &'r str {
+    pub const fn http_version(&self) -> &'r str {
         self.http_version
     }
 
     /// Return the request headers
-    pub fn headers(&self) -> Headers<'r> {
+    pub const fn headers(&self) -> Headers<'r> {
         self.headers
     }
 }
@@ -431,7 +431,7 @@ impl<'r, R: Read> crate::io::ErrorType for RequestBodyReader<'r, R> {
 
 impl<'r, R: Read> RequestBodyReader<'r, R> {
     /// Returns the total length of the body
-    pub fn content_length(&self) -> usize {
+    pub const fn content_length(&self) -> usize {
         self.content_length
     }
 }
@@ -488,17 +488,17 @@ pub struct RequestBody<'r, R: Read> {
 
 impl<'r, R: Read> RequestBody<'r, R> {
     /// The total length of the body
-    pub fn content_length(&self) -> usize {
+    pub const fn content_length(&self) -> usize {
         self.content_length
     }
 
     /// The size of the buffer used to read the body into
-    pub fn buffer_length(&self) -> usize {
+    pub const fn buffer_length(&self) -> usize {
         self.buffer.len()
     }
 
     /// Does the entire body fit into the buffer?
-    pub fn entire_body_fits_into_buffer(&self) -> bool {
+    pub const fn entire_body_fits_into_buffer(&self) -> bool {
         self.content_length() <= self.buffer_length()
     }
 
@@ -552,7 +552,7 @@ pub struct RequestBodyConnection<'r, R: Read> {
 
 impl<'r, R: Read> RequestBodyConnection<'r, R> {
     /// Return the total length of the body
-    pub fn content_length(&self) -> usize {
+    pub const fn content_length(&self) -> usize {
         self.content_length
     }
 

--- a/src/response/status.rs
+++ b/src/response/status.rs
@@ -6,37 +6,37 @@ pub struct StatusCode(u16);
 
 impl StatusCode {
     /// Create a status code with the given numerical value.
-    pub fn new(status_code: u16) -> Self {
+    pub const fn new(status_code: u16) -> Self {
         Self(status_code)
     }
 
     /// Convert a status code into the underlying numerical value.
-    pub fn as_u16(self) -> u16 {
+    pub const fn as_u16(self) -> u16 {
         self.0
     }
 
     /// Is the status code with the 1xx range
-    pub fn is_informational(&self) -> bool {
+    pub const fn is_informational(&self) -> bool {
         200 > self.0 && self.0 >= 100
     }
 
     /// Is the status code with the 2xx range
-    pub fn is_success(&self) -> bool {
+    pub const fn is_success(&self) -> bool {
         300 > self.0 && self.0 >= 200
     }
 
     /// Is the status code with the 3xx range
-    pub fn is_redirection(&self) -> bool {
+    pub const fn is_redirection(&self) -> bool {
         400 > self.0 && self.0 >= 300
     }
 
     /// Is the status code with the 4xx range
-    pub fn is_client_error(&self) -> bool {
+    pub const fn is_client_error(&self) -> bool {
         500 > self.0 && self.0 >= 400
     }
 
     /// Is the status code with the 5xx range
-    pub fn is_server_error(&self) -> bool {
+    pub const fn is_server_error(&self) -> bool {
         600 > self.0 && self.0 >= 500
     }
 }

--- a/src/url_encoded.rs
+++ b/src/url_encoded.rs
@@ -41,7 +41,7 @@ pub enum UrlDecodedCharacter {
 
 impl UrlDecodedCharacter {
     /// Convert into a [char], ignoring whether the character was present in the encoded string or percent-encoded.
-    pub fn into_char(self) -> char {
+    pub const fn into_char(self) -> char {
         match self {
             UrlDecodedCharacter::Literal(c) | UrlDecodedCharacter::Encoded(c) => c,
         }
@@ -276,7 +276,7 @@ impl<'a> UrlEncodedString<'a> {
     }
 
     /// Returns true if the string has a length of 0.
-    pub fn is_empty(self) -> bool {
+    pub const fn is_empty(self) -> bool {
         self.0.is_empty()
     }
 


### PR DESCRIPTION
`StatusCode`'s and others' methods are not const, which removes 2 embedded use cases:

- Constructing types in const environments
- Using power of the compiler to prove no side effects during runtime 

At the moment Rust does not support const traits etc, but if functions that *can* be const *would* be const, it might benefit some developers, whine not requiring any extra code in the lib