### PR TITLE
bump to embassy-net 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ categories = ["asynchronous", "network-programming", "web-programming::http-serv
 const-sha1 = { version = "0.3.0", default-features = false }
 data-encoding = { version = "2.4.0", default-features = false }
 defmt = { version = "0.3.6", optional = true }
-embassy-net = { version = "0.4.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
+embassy-net = { version = "0.5.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
 embassy-time = { version = "0.3.0", optional = true }
 embedded-io-async = "0.6.0"
 futures-util = { version = "0.3.28", default-features = false }


### PR DESCRIPTION
**edit** the updated API is now released with `embassy-net` 0.5.0.

This updates the embassy support to the [recently](https://github.com/embassy-rs/embassy/pull/3329) changed Stack API.

The upstream changes include:

1. dropping the Device generic parameter from `Stack`
2. adding a lifetime parameter
3. making `Stack` `Copy`

I have introduced the changes behind a feature `embassy-stack-is-copy` so old and new can co-exist.
This iteration only supports `'static'` as Stack lifetime, which resembles the previous behavior.