### PR TITLE
Bump embassy version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ name = "picoserve"
 version = "0.13.3"
 authors = ["Samuel Hicks"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 description = "An async no_std HTTP server suitable for bare-metal environments"
 readme = "README.md"
 repository = "https://github.com/sammhicks/picoserve"
@@ -39,8 +39,8 @@ categories = ["asynchronous", "network-programming", "web-programming::http-serv
 const-sha1 = { version = "0.3.0", default-features = false }
 data-encoding = { version = "2.4.0", default-features = false }
 defmt = { version = "0.3.6", optional = true }
-embassy-net = { version = "0.5.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
-embassy-time = { version = "0.3.0", optional = true }
+embassy-net = { version = "0.6.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
+embassy-time = { version = "0.4.0", optional = true }
 embedded-io-async = "0.6.0"
 futures-util = { version = "0.3.28", default-features = false }
 heapless = { version = "0.8.0", features = ["serde"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.79"
+channel = "1.80"


### PR DESCRIPTION
Hi, 

I updated the embassy dependencies. This also requires to increase the rust version to 1.80 because `smoltcp@0.12` requires it.