### PR TITLE
Added "serve_custom_socket" to the API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ name = "picoserve"
 version = "0.13.3"
 authors = ["Samuel Hicks"]
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.80"
 description = "An async no_std HTTP server suitable for bare-metal environments"
 readme = "README.md"
 repository = "https://github.com/sammhicks/picoserve"
@@ -39,8 +39,8 @@ categories = ["asynchronous", "network-programming", "web-programming::http-serv
 const-sha1 = { version = "0.3.0", default-features = false }
 data-encoding = { version = "2.4.0", default-features = false }
 defmt = { version = "0.3.6", optional = true }
-embassy-net = { version = "0.5.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
-embassy-time = { version = "0.3.0", optional = true }
+embassy-net = { version = "0.6.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
+embassy-time = { version = "0.4.0", optional = true }
 embedded-io-async = "0.6.0"
 futures-util = { version = "0.3.28", default-features = false }
 heapless = { version = "0.8.0", features = ["serde"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.79"
+channel = "1.80"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,8 +331,8 @@ pub async fn serve<P: routing::PathRouter>(
 ///
 /// This variant does not use the embassy_net::tcp::TcpSocket, but the
 /// (internal) picoserve socket. This is useful in cases where a 3rd party TCP
-/// stack and (custom) socket to that are used. It is far easier to implement a
-/// picoserve socket then an embassy-net socket.
+/// stack, and (custom) socket to that, are used. It is far easier to implement
+/// a picoserve socket, than an embassy-net socket.
 #[cfg(feature = "embassy")]
 pub async fn serve_custom_socket<P: routing::PathRouter, S: io::Socket>(
     app: &Router<P>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,22 @@ pub async fn serve<P: routing::PathRouter>(
     serve_and_shutdown(app, time::EmbassyTimer, config, buffer, socket, &()).await
 }
 
+/// Serve 'app' with incoming requests. App has no state.
+///
+/// This variant does not use the embassy_net::tcp::TcpSocket, but the
+/// (internal) picoserve socket. This is useful in cases where a 3rd party TCP
+/// stack and (custom) socket to that are used. It is far easier to implement a
+/// picoserve socket then an embassy-net socket.
+#[cfg(feature = "embassy")]
+pub async fn serve_custom_socket<P: routing::PathRouter, S: io::Socket>(
+    app: &Router<P>,
+    config: &Config<embassy_time::Duration>,
+    buffer: &mut [u8],
+    socket: S,
+) -> Result<u64, Error<S::Error>> {
+    serve_and_shutdown(app, time::EmbassyTimer, config, buffer, socket, &()).await
+}
+
 #[cfg(feature = "embassy")]
 /// Serve `app` with incoming requests. App has a state of `State`.
 pub async fn serve_with_state<State, P: routing::PathRouter<State>>(


### PR DESCRIPTION
First off, thank you for this crate, and for maintaining it!

For our (a friend is helping out) application, we have a WiFi module with an internal TCP/IP stack. This means that we don't need to use the embassy TCP/IP stack, as the module offers a TCP socket directly (with some limitations that don't matter in our use case).

This means that the picoserve API, as far as we understand it, won't work, as it assumes that the embassy stack is used. Unfortunately, implementing an embassy-compatible, pass-through socket is rather the endeavor...

To allow for our use case, I've added a minor variation on the "serve" function, that takes a picoserve socket instead. (Thus just wrapping the "serve_and_shutdown" function.)

As a pass-through picoserve socket is easy to implement (compared to the embassy one), this change allows basically any TCP socket data source to be linked to picoserve, by implementing the light-weight picoserve socket, to link the data streams and handle any shut-down.

I've made this PR in the hope that it may be useful to others. If there is a better way of doing this, I'd welcome the input!

(One last thing: I haven't quite figured-out how to untangle the commits in this branch, and have unintentionally "doubled-up" the PR by hodasemi in here. Please ignore that commit in here, and let honor be where honor is due. I required this PR to work with the latest embassy release.)