### PR TITLE
Loosen version of embassy dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ categories = ["asynchronous", "network-programming", "web-programming::http-serv
 const-sha1 = { version = "0.3.0", default-features = false }
 data-encoding = { version = "2.4.0", default-features = false }
 defmt = { version = "0.3.6", optional = true }
-embassy-net = { version = "0.5.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
-embassy-time = { version = "0.3.0", optional = true }
+embassy-net = { version = ">=0.5.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
+embassy-time = { version = ">=0.3.0", optional = true }
 embedded-io-async = "0.6.0"
 futures-util = { version = "0.3.28", default-features = false }
 heapless = { version = "0.8.0", features = ["serde"] }


### PR DESCRIPTION
Embassy is currently moving quite quickly.
But apparently the API is stable enough so that it doesn't break picoserve.

sntpc approaches this by [setting a minimal version](https://github.com/vpetrigo/sntpc/blob/master/sntpc/Cargo.toml#L37) of embassy-*.
This PR does the same for picoserve.