### PR TITLE
DRAFT: Rust `stable` compatibility

### DIFF
--- a/picoserve/src/lib.rs
+++ b/picoserve/src/lib.rs
@@ -453,23 +453,21 @@ pub trait AppBuilder {
 /// In practice usage requires the nightly Rust toolchain.
 pub trait AppWithStateBuilder {
     type State;
-    type PathRouter: routing::PathRouter<Self::State>;
 
-    fn build_app(self) -> Router<Self::PathRouter, Self::State>;
+    fn build_app(self) -> Router<impl routing::PathRouter<Self::State>, Self::State>;
 }
 
 impl<T: AppBuilder> AppWithStateBuilder for T {
     type State = ();
-    type PathRouter = <Self as AppBuilder>::PathRouter;
 
-    fn build_app(self) -> Router<Self::PathRouter, Self::State> {
+    fn build_app(self) -> Router<impl routing::PathRouter, Self::State> {
         <Self as AppBuilder>::build_app(self)
     }
 }
 
 /// The [Router] for the app constructed from the Props (which implement [AppBuilder]).
 pub type AppRouter<Props> =
-    Router<<Props as AppWithStateBuilder>::PathRouter, <Props as AppWithStateBuilder>::State>;
+    Router<dyn routing::PathRouter<<Props as AppWithStateBuilder>::State>, <Props as AppWithStateBuilder>::State>;
 
 /// Replacement for [`static_cell::make_static`](https://docs.rs/static_cell/latest/static_cell/macro.make_static.html) for use cases when the type is known.
 #[macro_export]

--- a/picoserve/src/lib.rs
+++ b/picoserve/src/lib.rs
@@ -466,8 +466,10 @@ impl<T: AppBuilder> AppWithStateBuilder for T {
 }
 
 /// The [Router] for the app constructed from the Props (which implement [AppBuilder]).
-pub type AppRouter<Props> =
-    Router<dyn routing::PathRouter<<Props as AppWithStateBuilder>::State>, <Props as AppWithStateBuilder>::State>;
+pub type AppRouter<Props> = Router<
+    dyn routing::PathRouter<<Props as AppWithStateBuilder>::State>,
+    <Props as AppWithStateBuilder>::State,
+>;
 
 /// Replacement for [`static_cell::make_static`](https://docs.rs/static_cell/latest/static_cell/macro.make_static.html) for use cases when the type is known.
 #[macro_export]

--- a/picoserve_derive/src/lib.rs
+++ b/picoserve_derive/src/lib.rs
@@ -44,15 +44,11 @@ fn status_code_attr(attrs: &[syn::Attribute]) -> Result<Option<StatusCodeAttr>, 
 
         let status_code = &meta_list.tokens;
 
-        return Ok(Some(
-
-        if status_code.to_string() == "transparent" {
+        return Ok(Some(if status_code.to_string() == "transparent" {
             StatusCodeAttr::Transparent
         } else {
-
-        StatusCodeAttr::StatusCode(
-            quote! { picoserve::response::StatusCode::#status_code },
-        )}));
+            StatusCodeAttr::StatusCode(quote! { picoserve::response::StatusCode::#status_code })
+        }));
     }
 }
 
@@ -71,18 +67,15 @@ fn try_derive_error_with_status_code(
             StatusCodeAttr::StatusCode(token_stream) => token_stream,
             StatusCodeAttr::Transparent => {
                 let fields = single_field(&data_struct.fields).ok_or_else(|| {
-                    syn::Error::new_spanned(
-                        input,
-                        "transparent errors must have a single field",
-                    )
+                    syn::Error::new_spanned(input, "transparent errors must have a single field")
                 })?;
 
                 quote! {
                     let Self #fields = self;
                     picoserve::response::ErrorWithStatusCode::status_code(field)
                 }
-            },
-        }
+            }
+        },
         syn::Data::Enum(data_enum) => {
             let cases = data_enum
                 .variants
@@ -165,9 +158,8 @@ fn try_derive_error_with_status_code(
     })
 }
 
-
 /// Derive `ErrorWithStatusCode` for a struct or an enum.
-/// 
+///
 /// This will also derive `IntoResponse`, returning a `Response` with the given status code and a `text/plain` body of the `Display` implementation.
 ///
 /// # Structs
@@ -179,10 +171,10 @@ fn try_derive_error_with_status_code(
 /// # Enums
 ///
 /// There may be an attribute `status_code` on the enum itself containing the default StatusCode of the error.
-/// 
+///
 /// There may also be an attribute `status_code` on a variant, which overrides the default StatusCode.
 /// If all variants have their own attribute `status_code`, the default may be omitted.
-/// 
+///
 /// Variants with a `status_code` of transparent must contain a single field which implements `ErrorWithStatusCode`.
 #[proc_macro_derive(ErrorWithStatusCode, attributes(status_code))]
 pub fn derive_error_with_status_code(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
This PR updates the type signatures for AppBuilder related types and traits to enable usage with `stable` rust.

EDIT:
Well I have to admit defeat, the constraints placed on embassy tasks function signatures do not allow for simply moving types constraints out of associated types. At least not without going way deeper into the router structure which would probably involve a significant rewrite.

Kind regards
ju6ge