### PR TITLE
Add example code to stop a server

### DIFF
--- a/examples/embassy/Cargo.toml
+++ b/examples/embassy/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "example_secrets",
     "hello_world",
     "set_pico_w_led",
+    "stop_server",
     "various_states",
     "web_sockets"
 ]
@@ -14,19 +15,19 @@ exclude = [
 
 [workspace.dependencies]
 cortex-m-rt = "0.7.3"
-cyw43 = { version = "0.3.0", features = ["firmware-logs"] }
-cyw43-pio = "0.4.0"
-embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "nightly"] }
+cyw43 = { version = "0.5.0", features = ["firmware-logs"] }
+cyw43-pio = "0.8.0"
+embassy-executor = { version = "0.9.1", features = ["arch-cortex-m", "executor-thread", "nightly"] }
 embassy-futures = "0.1.1"
 embassy-net = { version = "0.7.0", features = ["tcp", "proto-ipv4", "medium-ethernet"] }
-embassy-rp = { version = "0.4.0", features = ["rp2040", "critical-section-impl", "time-driver"] }
-embassy-sync = "0.6.0"
-embassy-time = "0.4.0"
-embassy-usb-logger = "0.4.0"
+embassy-rp = { version = "0.8.0", features = ["rp2040", "critical-section-impl", "time-driver"] }
+embassy-sync = "0.7.2"
+embassy-time = "0.5.0"
+embassy-usb-logger = "0.5.1"
 embedded-io-async = "0.6.1"
 log = { version = "0.4.22", default-features = false }
 panic-persist = { version = "0.3.0", features = ["utf8"] }
 picoserve = { path = "../../picoserve", features = ["embassy", "log"] }
 portable-atomic = { version = "1.7.0", features = ["critical-section"], default-features = false }
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.2", default-features = false }
 static_cell = "2.1.0"

--- a/examples/embassy/stop_server/Cargo.toml
+++ b/examples/embassy/stop_server/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "stop_server"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m-rt = { workspace = true }
+cyw43 = { workspace = true }
+cyw43-pio = { workspace = true }
+embassy-executor = { workspace = true }
+embassy-futures = { workspace = true }
+embassy-net = { workspace = true }
+embassy-rp = { workspace = true }
+embassy-sync = { workspace = true }
+embassy-time = { workspace = true }
+embassy-usb-logger = { workspace = true }
+embedded-io-async = { workspace = true }
+log = { workspace = true }
+panic-persist = { workspace = true }
+picoserve = { workspace = true }
+portable-atomic = { workspace = true }
+rand = { workspace = true }
+static_cell = { workspace = true }
+example_secrets = { path = "../example_secrets" }

--- a/examples/embassy/stop_server/src/main.rs
+++ b/examples/embassy/stop_server/src/main.rs
@@ -1,0 +1,186 @@
+#![no_std]
+#![no_main]
+#![feature(impl_trait_in_assoc_type)]
+
+use cyw43_pio::PioSpi;
+use embassy_rp::{
+    gpio::{Level, Output},
+    peripherals::{DMA_CH0, PIO0},
+    pio::Pio,
+};
+
+use embassy_time::Duration;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex};
+use panic_persist as _;
+use picoserve::{make_static, routing::get, AppBuilder, AppRouter};
+use rand::Rng;
+
+embassy_rp::bind_interrupts!(struct Irqs {
+    PIO0_IRQ_0 => embassy_rp::pio::InterruptHandler<embassy_rp::peripherals::PIO0>;
+    USBCTRL_IRQ => embassy_rp::usb::InterruptHandler<embassy_rp::peripherals::USB>;
+});
+
+#[embassy_executor::task]
+
+async fn logger_task(driver: embassy_rp::usb::Driver<'static, embassy_rp::peripherals::USB>) {
+    embassy_usb_logger::run!(1024, log::LevelFilter::Info, driver);
+}
+
+#[embassy_executor::task]
+async fn wifi_task(
+    runner: cyw43::Runner<'static, Output<'static>, PioSpi<'static, PIO0, 0, DMA_CH0>>,
+) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn net_task(mut stack: embassy_net::Runner<'static, cyw43::NetDriver<'static>>) -> ! {
+    stack.run().await
+}
+
+struct AppProps;
+
+impl AppBuilder for AppProps {
+    type PathRouter = impl picoserve::routing::PathRouter;
+
+    fn build_app(self) -> picoserve::Router<Self::PathRouter> {
+        picoserve::Router::new().route("/", get(|| async move { "Hello World" }))
+    }
+}
+
+const WEB_TASK_POOL_SIZE: usize = 8;
+
+type WorkerSignal = embassy_sync::signal::Signal<CriticalSectionRawMutex, ()>;
+static WORKER_SIGNALS: [WorkerSignal; WEB_TASK_POOL_SIZE] = [const { WorkerSignal::new() }; WEB_TASK_POOL_SIZE];
+
+#[embassy_executor::task(pool_size = WEB_TASK_POOL_SIZE)]
+async fn web_task(
+    id: usize,
+    stack: embassy_net::Stack<'static>,
+    app: &'static AppRouter<AppProps>,
+    config: &'static picoserve::Config<Duration>,
+) -> ! {
+    let port = 80;
+    let mut tcp_rx_buffer = [0; 1024];
+    let mut tcp_tx_buffer = [0; 1024];
+    let mut http_buffer = [0; 2048];
+
+    picoserve::listen_and_serve(
+        id,
+        app,
+        config,
+        stack,
+        port,
+        &mut tcp_rx_buffer,
+        &mut tcp_tx_buffer,
+        &mut http_buffer,
+    )
+    .await
+}
+
+async fn start_server(
+    spawner: embassy_executor::Spawner,
+    stack: embassy_net::Stack<'static>,
+    app: &'static AppRouter<AppProps>,
+    config: &'static picoserve::Config<Duration>,
+) {
+    for id in 0..WEB_TASK_POOL_SIZE {
+        let signal = &WORKER_SIGNALS[id];
+        signal.reset();
+
+        spawner.must_spawn(web_task(id, stack, app, config));
+    }
+}
+
+async fn stop_server() {
+    for signal in &WORKER_SIGNALS {
+        signal.signal(());
+    }
+}
+
+#[embassy_executor::main]
+async fn main(spawner: embassy_executor::Spawner) {
+    let p = embassy_rp::init(Default::default());
+
+    let driver = embassy_rp::usb::Driver::new(p.USB, Irqs);
+    spawner.must_spawn(logger_task(driver));
+
+    if let Some(panic_message) = panic_persist::get_panic_message_utf8() {
+        loop {
+            log::error!("{panic_message}");
+            embassy_time::Timer::after_secs(5).await;
+        }
+    }
+
+    let fw = include_bytes!("../../cyw43-firmware/43439A0.bin");
+    let clm = include_bytes!("../../cyw43-firmware/43439A0_clm.bin");
+
+    let pwr = Output::new(p.PIN_23, Level::Low);
+    let cs = Output::new(p.PIN_25, Level::High);
+    let mut pio = Pio::new(p.PIO0, Irqs);
+    let spi = cyw43_pio::PioSpi::new(
+        &mut pio.common,
+        pio.sm0,
+        cyw43_pio::RM2_CLOCK_DIVIDER,
+        pio.irq0,
+        cs,
+        p.PIN_24,
+        p.PIN_29,
+        p.DMA_CH0,
+    );
+
+    let state = make_static!(cyw43::State, cyw43::State::new());
+    let (net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
+    spawner.must_spawn(wifi_task(runner));
+
+    control.init(clm).await;
+
+    let (stack, runner) = embassy_net::new(
+        net_device,
+        embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+            address: embassy_net::Ipv4Cidr::new(core::net::Ipv4Addr::new(192, 168, 0, 1), 24),
+            gateway: None,
+            dns_servers: Default::default(),
+        }),
+        make_static!(
+            embassy_net::StackResources<WEB_TASK_POOL_SIZE>,
+            embassy_net::StackResources::new()
+        ),
+        embassy_rp::clocks::RoscRng.gen(),
+    );
+
+    spawner.must_spawn(net_task(runner));
+
+    control
+        .start_ap_wpa2(
+            example_secrets::WIFI_SSID,
+            example_secrets::WIFI_PASSWORD,
+            8,
+        )
+        .await;
+
+    let app = make_static!(AppRouter<AppProps>, AppProps.build_app());
+
+    let config = make_static!(
+        picoserve::Config<Duration>,
+        picoserve::Config::new(picoserve::Timeouts {
+            start_read_request: Some(Duration::from_secs(5)),
+            persistent_start_read_request: Some(Duration::from_secs(1)),
+            read_request: Some(Duration::from_secs(1)),
+            write: Some(Duration::from_secs(1)),
+        })
+        .keep_connection_alive()
+    );
+
+    log::info!("Starting server");
+    start_server(spawner, stack, app, config).await;
+    log::info!("Server started");
+    embassy_time::Timer::after_secs(60).await;
+    stop_server().await;
+    log::info!("Server stopped");
+    embassy_time::Timer::after_secs(60).await;
+
+    log::info!("Starting server once more");
+    start_server(spawner, stack, app, config).await;
+    log::info!("Server started");
+}


### PR DESCRIPTION
This is an alternative approach to fix issue #96 

This just adds a code example on how to stop a running server.

Note: I had to update dependencies as code currently wasn't compiling. I possible broke some examples, but hello_world wasn't running anyway for me... (So either I am doing something wrong, or the project isn't properly keeping the examples working)

I also did not run this on a device as deploying didn't work; I do have a RP2350 instead of RP2400, it should be a matter of properly configuring the target which I tried, but still got a weird error.
As its late I didn't bother to investigate.

If any interest I could clean up the PR later;

I tested the logic in my own program first, so  I assume as long as it compiles it should work.