### PR TITLE
Add missing required space in status line of HTTP response

### DIFF
--- a/picoserve/src/response/response_stream.rs
+++ b/picoserve/src/response/response_stream.rs
@@ -61,7 +61,7 @@ impl<W: Write> super::ResponseWriter for ResponseStream<W> {
         }
 
         use crate::io::WriteExt;
-        write!(self.writer, "HTTP/1.1 {status_code}\r\n").await?;
+        write!(self.writer, "HTTP/1.1 {status_code} \r\n").await?;
 
         headers
             .for_each_header(HeadersWriter {


### PR DESCRIPTION
See https://www.rfc-editor.org/rfc/rfc9112#name-status-line

Closes https://github.com/sammhicks/picoserve/issues/102