### PR TITLE
Limit embassy-net version to less than 0.8

### DIFF
--- a/picoserve/Cargo.toml
+++ b/picoserve/Cargo.toml
@@ -21,7 +21,7 @@ features = ["tokio", "embassy", "json", "ws"]
 const-sha1 = { version = "0.3.0", default-features = false }
 data-encoding = { version = "2.4.0", default-features = false, optional = true }
 defmt = { version = "1.0.1", optional = true }
-embassy-net = { version = ">=0.6.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
+embassy-net = { version = ">=0.6.0, <0.8.0", optional = true, features = ["tcp", "proto-ipv4", "medium-ethernet"] }
 embassy-time = { version = ">=0.4.0", optional = true }
 embedded-io-async = "0.6.0"
 heapless = { version = "0.8.0", features = ["serde"] }


### PR DESCRIPTION
The embassy project has released embassy-net 0.8. This breaks the use of picoserve because picoserve does not limit the version of embassy-net. As a result, picoserve pulls in embassy-net 0.8.