### PR TITLE
Make rust analyzer work better

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "rust-analyzer.rustfmt.extraArgs": [
+    "+nightly"
+  ],
+  // Uncomment the target of your chip.
+  "rust-analyzer.cargo.target": "thumbv6m-none-eabi",
+  //"rust-analyzer.cargo.target": "thumbv7m-none-eabi",
+  // "rust-analyzer.cargo.target": "thumbv7em-none-eabi",
+  //"rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
+  // "rust-analyzer.cargo.target": "thumbv8m.main-none-eabihf",
+  "rust-analyzer.linkedProjects": [
+    "examples/embassy/Cargo.toml",
+    "examples/embassy/hello_world_defmt/Cargo.toml",
+  ],
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,15 +13,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "byteorder"
@@ -57,70 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chunked_response"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
-name = "conditional_routing"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
 name = "const-sha1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "custom_extractor"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "serde",
- "thiserror",
- "tokio",
-]
 
 [[package]]
 name = "data-encoding"
@@ -167,16 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -319,36 +231,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "form"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "heapless 0.8.0",
- "log",
- "picoserve",
- "pretty_env_logger",
- "serde",
- "tokio",
-]
 
 [[package]]
 name = "futures-channel"
@@ -364,17 +250,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "futures-sink"
@@ -395,57 +270,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
- "futures-macro",
  "futures-task",
  "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "graceful_shutdown"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "futures-util",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
-name = "graceful_shutdown_server_sent_events"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "futures-util",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
-name = "graceful_shutdown_web_sockets"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "futures-util",
- "log",
- "picoserve",
- "pretty_env_logger",
- "serde",
- "tokio",
 ]
 
 [[package]]
@@ -487,34 +313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hello_world"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
-name = "hello_world_single_thread"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,24 +352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "huge_requests"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "sha2",
- "tokio",
-]
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
 name = "hyper"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,32 +382,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "layers"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
 
 [[package]]
 name = "lhash"
@@ -692,17 +450,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
-name = "nested_router"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
 name = "ntest"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,18 +480,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "path_parameters"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "serde",
- "tokio",
 ]
 
 [[package]]
@@ -811,16 +546,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,87 +586,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "query"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "heapless 0.8.0",
- "log",
- "picoserve",
- "pretty_env_logger",
- "serde",
- "tokio",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "request_info"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
-name = "response_using_state"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
-name = "routing_fallback"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
 ]
 
 [[package]]
@@ -993,35 +643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "server_sent_events"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,55 +679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "state"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "state_local"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "state_multiple"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "log",
- "picoserve",
- "pretty_env_logger",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "static_content"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "heapless 0.8.0",
- "log",
- "picoserve",
- "pretty_env_logger",
- "serde",
- "tokio",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,15 +698,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -1220,22 +783,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -1257,27 +808,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "web_sockets"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "futures-util",
- "log",
- "picoserve",
- "pretty_env_logger",
- "tokio",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys",
-]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
 ]
 exclude = [
     "examples/embassy",
+    "examples/embassy/hello_world_defmt",
 ]
 
 [workspace.dependencies]

--- a/examples/embassy/app_with_props/Cargo.toml
+++ b/examples/embassy/app_with_props/Cargo.toml
@@ -26,3 +26,10 @@ rand = { workspace = true }
 static_cell = { workspace = true }
 example_secrets = { path = "../example_secrets" }
 example_utils = { path = "../example_utils" }
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[[bin]]
+name = "app_with_props"
+test = false
+bench = false

--- a/examples/embassy/example_secrets/Cargo.toml
+++ b/examples/embassy/example_secrets/Cargo.toml
@@ -6,3 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[lib]
+name = "example_secrets"
+test = false
+bench = false

--- a/examples/embassy/example_utils/Cargo.toml
+++ b/examples/embassy/example_utils/Cargo.toml
@@ -7,3 +7,10 @@ edition = "2024"
 embassy-rp = { workspace = true }
 embassy-sync = { workspace = true }
 embassy-usb-logger = { workspace = true }
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[lib]
+name = "example_utils"
+test = false
+bench = false

--- a/examples/embassy/graceful_shutdown_using_future_array/Cargo.toml
+++ b/examples/embassy/graceful_shutdown_using_future_array/Cargo.toml
@@ -26,3 +26,10 @@ rand = { workspace = true }
 static_cell = { workspace = true }
 example_secrets = { path = "../example_secrets" }
 example_utils = { path = "../example_utils" }
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[[bin]]
+name = "graceful_shutdown_using_future_array"
+test = false
+bench = false

--- a/examples/embassy/graceful_shutdown_using_tasks/Cargo.toml
+++ b/examples/embassy/graceful_shutdown_using_tasks/Cargo.toml
@@ -26,3 +26,10 @@ rand = { workspace = true }
 static_cell = { workspace = true }
 example_secrets = { path = "../example_secrets" }
 example_utils = { path = "../example_utils" }
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[[bin]]
+name = "graceful_shutdown_using_tasks"
+test = false
+bench = false

--- a/examples/embassy/hello_world/Cargo.toml
+++ b/examples/embassy/hello_world/Cargo.toml
@@ -26,3 +26,10 @@ rand = { workspace = true }
 static_cell = { workspace = true }
 example_secrets = { path = "../example_secrets" }
 example_utils = { path = "../example_utils" }
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[[bin]]
+name = "hello_world"
+test = false
+bench = false

--- a/examples/embassy/hello_world_defmt/Cargo.toml
+++ b/examples/embassy/hello_world_defmt/Cargo.toml
@@ -32,3 +32,10 @@ example_secrets = { path = "../example_secrets" }
 # Rust debug is too slow.
 # For debug builds always builds with some optimization
 opt-level = "s"
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[[bin]]
+name = "hello_world_defmt"
+test = false
+bench = false

--- a/examples/embassy/huge_requests/Cargo.toml
+++ b/examples/embassy/huge_requests/Cargo.toml
@@ -27,3 +27,10 @@ sha2 = { version = "0.10.9", default-features = false }
 static_cell = { workspace = true }
 example_secrets = { path = "../example_secrets" }
 example_utils = { path = "../example_utils" }
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[[bin]]
+name = "huge_requests"
+test = false
+bench = false

--- a/examples/embassy/set_pico_w_led/Cargo.toml
+++ b/examples/embassy/set_pico_w_led/Cargo.toml
@@ -26,3 +26,10 @@ rand = { workspace = true }
 static_cell = { workspace = true }
 example_secrets = { path = "../example_secrets" }
 example_utils = { path = "../example_utils" }
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[[bin]]
+name = "set_led"
+test = false
+bench = false

--- a/examples/embassy/various_states/Cargo.toml
+++ b/examples/embassy/various_states/Cargo.toml
@@ -26,3 +26,10 @@ rand = { workspace = true }
 static_cell = { workspace = true }
 example_secrets = { path = "../example_secrets" }
 example_utils = { path = "../example_utils" }
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[[bin]]
+name = "various_states"
+test = false
+bench = false

--- a/examples/embassy/web_sockets/Cargo.toml
+++ b/examples/embassy/web_sockets/Cargo.toml
@@ -26,3 +26,10 @@ rand = { workspace = true }
 static_cell = { workspace = true }
 example_secrets = { path = "../example_secrets" }
 example_utils = { path = "../example_utils" }
+
+# Below configs are here to mute the rust-analyzer error.
+# "Can't find crate for 'test'" as this is a no_std project
+[[bin]]
+name = "web_sockets"
+test = false
+bench = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.93"
+components = ["rust-analyzer"]


### PR DESCRIPTION
This makes rust-analyzer in VS Code not complain and actually works with embassy examples.

I saw that `Cargo.toml` explicitly excludes `examples/embassy` and that changing that does not work. I used `.vscode/settings.json` like how embassy itself does it.

In more detail:

1. When I would open the picoserve project in VS Code, I would get this dialog.

<img width="530" height="196" alt="Your workspace uses a rust-toolchain file with a toolchain too old for the extension" src="https://github.com/user-attachments/assets/6339ee1b-3edd-46e9-9a69-df6ab00a96f5" />


The first commit simply adds the `components = ["rust-analyzer"]` line which makes that dialog not appear anymore.

2. When I would hover over some things in the embassy examples (e.g. `DEFAULT_CLOCK_DIVIDER` in the embassy hello world example) nothing would be show about it. Adding the `.vscode/settings.json` file based on the one in the embassy repository fixed this.
3. At that point, VS Code shows an error at the top of every `main.rs` and `lib.rs` file in the embassy examples saying "can't find crate for test". Adding a section to the the `Cargo.toml` files fixes this. Thanks to [the bentwire/embassy-rp2040-template repository](https://github.com/bentwire/embassy-rp2040-template/blob/1ef9628891fe9a2b5d8ca1a4b7496e57dcbcf4a8/Cargo.toml#L59-L64) for the knowledge of this fix.

(Edit: Updated with "more detail" now that this is ready for review.)