### PR TITLE
Optimize size of run_with_timer and serve_and_shutdown futures

### DIFF
--- a/picoserve/src/futures.rs
+++ b/picoserve/src/futures.rs
@@ -8,9 +8,22 @@ use core::{
 use futures_util::TryFuture;
 use pin_project::pin_project;
 
+#[pin_project::pin_project(project = EitherProj)]
 pub enum Either<A, B> {
-    First(A),
-    Second(B),
+    First(#[pin] A),
+    Second(#[pin] B),
+}
+
+/// Polls whichever variant is present in Either instnace.
+impl<A: Future, B: Future<Output = A::Output>> Future for Either<A, B> {
+    type Output = A::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            EitherProj::First(f) => f.poll(cx),
+            EitherProj::Second(f) => f.poll(cx),
+        }
+    }
 }
 
 impl<A> Either<A, core::convert::Infallible> {

--- a/picoserve/src/lib.rs
+++ b/picoserve/src/lib.rs
@@ -351,6 +351,12 @@ async fn serve_and_shutdown<
             }
         };
 
+        // What to do after handling one request: keep looping, or stop serving and return.
+        enum LoopResult<ShutdownReason, E: io::Error> {
+            Continue,
+            Stop(Result<DisconnectionInfo<ShutdownReason>, Error<E>>),
+        }
+
         loop {
             let request_count = request_count_iter();
 
@@ -404,8 +410,16 @@ async fn serve_and_shutdown<
             .await
             .first_is_error()?;
 
-            match request {
-                Ok(request) => {
+            // Both async match arms on `request` contain large variables or futures,
+            // and the compiler does not recognize these are mutually exclusive blocks
+            // of code, so memory is allocated in the `serve and shutdown` future for
+            // both arms of the match.
+            // Force the compiler to alias this memory by encapsulating each arm in a
+            // async future held in a `futures::either`. Then we await the generic Either
+            // future. Because the two futures are forced into one enum, the compiler
+            // will always alias the memory.
+            let result_future = match request {
+                Ok(request) => futures::Either::First(async {
                     let connection_header = match config.connection {
                         KeepAlive::Close => KeepAlive::Close,
                         KeepAlive::KeepAlive => KeepAlive::from_request(
@@ -424,41 +438,45 @@ async fn serve_and_shutdown<
                     )
                     .map(futures::Either::ignore_never_a));
 
-                    return Ok(
-                        match crate::futures::select_either(
-                            shutdown_signal.as_mut(),
-                            handle_request.as_mut(),
-                        )
-                        .await
-                        {
-                            futures::Either::First((shutdown_reason, shutdown_timeout)) => {
-                                shutdown_broadcast.notify(());
+                    match crate::futures::select_either(
+                        shutdown_signal.as_mut(),
+                        handle_request.as_mut(),
+                    )
+                    .await
+                    {
+                        futures::Either::First((shutdown_reason, shutdown_timeout)) => {
+                            shutdown_broadcast.notify(());
 
-                                DisconnectionInfo::with_shutdown_reason(
-                                    match timer
-                                        .run_with_timeout(shutdown_timeout, handle_request)
-                                        .await
-                                        .swap_errors()?
-                                    {
-                                        Ok(ResponseSent(_)) => request_count + 1,
-                                        Err(time::TimeoutError) => request_count,
-                                    },
-                                    shutdown_reason,
-                                )
+                            LoopResult::Stop(Ok(DisconnectionInfo::with_shutdown_reason(
+                                match timer
+                                    .run_with_timeout(shutdown_timeout, handle_request)
+                                    .await
+                                    .swap_errors()
+                                {
+                                    Ok(Ok(ResponseSent(_))) => request_count + 1,
+                                    Ok(Err(time::TimeoutError)) => request_count,
+                                    Err(err) => return LoopResult::Stop(Err(err)),
+                                },
+                                shutdown_reason,
+                            )))
+                        }
+                        futures::Either::Second(response_sent) => {
+                            let ResponseSent(_) = match response_sent {
+                                Ok(sent) => sent,
+                                Err(err) => return LoopResult::Stop(Err(err)),
+                            };
+
+                            if let KeepAlive::KeepAlive = connection_header {
+                                LoopResult::Continue
+                            } else {
+                                LoopResult::Stop(Ok(DisconnectionInfo::no_shutdown_reason(
+                                    request_count + 1,
+                                )))
                             }
-                            futures::Either::Second(response_sent) => {
-                                let ResponseSent(_) = response_sent?;
-
-                                if let KeepAlive::KeepAlive = connection_header {
-                                    continue;
-                                }
-
-                                DisconnectionInfo::no_shutdown_reason(request_count + 1)
-                            }
-                        },
-                    );
-                }
-                Err(err) => {
+                        }
+                    }
+                }),
+                Err(err) => futures::Either::Second(async {
                     use response::IntoResponse;
 
                     let message = match err {
@@ -467,22 +485,31 @@ async fn serve_and_shutdown<
                             "Invalid Header line: No ':' character"
                         }
                         request::ReadError::UnexpectedEof => "Unexpected EOF while reading request",
-                        request::ReadError::IO(err) => return Err(err),
+                        request::ReadError::IO(err) => return LoopResult::Stop(Err(err)),
                     };
 
-                    let ResponseSent { .. } = timer
-                        .run_with_timeout(
-                            config.timeouts.write,
-                            (response::StatusCode::BAD_REQUEST, message).write_to(
-                                response::Connection::empty(&mut Default::default()),
-                                response::ResponseStream::new(writer, KeepAlive::Close),
-                            ),
-                        )
-                        .await
-                        .map_err(Error::WriteTimeout)??;
+                    LoopResult::Stop(
+                        match timer
+                            .run_with_timeout(
+                                config.timeouts.write,
+                                (response::StatusCode::BAD_REQUEST, message).write_to(
+                                    response::Connection::empty(&mut Default::default()),
+                                    response::ResponseStream::new(&mut writer, KeepAlive::Close),
+                                ),
+                            )
+                            .await
+                        {
+                            Ok(Ok(ResponseSent { .. })) => Err(Error::BadRequest),
+                            Ok(Err(err)) => Err(err),
+                            Err(err) => Err(Error::WriteTimeout(err)),
+                        },
+                    )
+                }),
+            };
 
-                    return Err(Error::BadRequest);
-                }
+            match result_future.await {
+                LoopResult::Continue => continue,
+                LoopResult::Stop(result) => return result,
             }
         }
     }

--- a/picoserve/src/sync/oneshot_broadcast.rs
+++ b/picoserve/src/sync/oneshot_broadcast.rs
@@ -24,7 +24,7 @@ impl<'a, T: Copy> Signal<'a, T> {
         }
     }
 
-    pub fn notify(self, value: T) {
+    pub fn notify(&self, value: T) {
         self.channel.value.set(Some(value));
 
         if let Some(waker) = self.channel.waker.take() {

--- a/picoserve/src/time.rs
+++ b/picoserve/src/time.rs
@@ -52,17 +52,58 @@ impl crate::io::Error for TimeoutError {
     }
 }
 
+/// A wrapper future for `F` which returns a Result of either `Ok(F::Output)`
+/// if the future `F` resolves within the timeout, otherwise it returns
+/// `Err(TimeoutError)`.
+/// This pattern of wrapping the given future in a custom generic polling
+/// implementation was chosen instead of a simple `async fn` which wraps the
+/// runtime timeout method, because the `future` argument would end up being
+/// captured twice, both as the argument to the `async fn` and in the future
+/// returned by the runtime.
+#[pin_project::pin_project]
+struct TimeoutFuture<F, TF> {
+    #[pin]
+    future: F,
+
+    #[pin]
+    timeout_future: TF,
+}
+
+impl<F: core::future::Future, TF: core::future::Future<Output = ()>> core::future::Future
+    for TimeoutFuture<F, TF>
+{
+    type Output = Result<F::Output, TimeoutError>;
+
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Self::Output> {
+        let this = self.project();
+
+        if let core::task::Poll::Ready(output) = this.future.poll(cx) {
+            return core::task::Poll::Ready(Ok(output));
+        }
+
+        if let core::task::Poll::Ready(()) = this.timeout_future.poll(cx) {
+            return core::task::Poll::Ready(Err(TimeoutError));
+        }
+
+        core::task::Poll::Pending
+    }
+}
+
 /// A timer which can be used to abort futures if they take to long to resolve.
 pub trait Timer<Runtime> {
     /// Create a future which resolves after `duration` has passed.
     async fn delay(&self, duration: Duration);
 
-    /// Drive the future, failing if it takes too long to resolve.
-    async fn run_with_timeout<F: core::future::Future>(
+    /// Return a future which will run the given future, failing with a
+    /// `TimeoutError` if it takes too long to resolve.
+    fn run_with_timeout<F: core::future::Future>(
         &self,
         duration: Duration,
         future: F,
-    ) -> Result<F::Output, TimeoutError>;
+    ) -> impl core::future::Future<Output = Result<F::Output, TimeoutError>>;
 }
 
 pub(crate) trait TimerExt<Runtime>: Timer<Runtime> {
@@ -86,17 +127,17 @@ impl Timer<super::TokioRuntime> for TokioTimer {
         tokio::time::sleep(std::time::Duration::from_millis(duration.as_millis())).await;
     }
 
-    async fn run_with_timeout<F: core::future::Future>(
+    fn run_with_timeout<F: core::future::Future>(
         &self,
         duration: Duration,
         future: F,
-    ) -> Result<F::Output, TimeoutError> {
-        tokio::time::timeout(
-            std::time::Duration::from_millis(duration.as_millis()),
+    ) -> impl core::future::Future<Output = Result<F::Output, TimeoutError>> {
+        TimeoutFuture {
             future,
-        )
-        .await
-        .map_err(|_: tokio::time::error::Elapsed| TimeoutError)
+            timeout_future: tokio::time::sleep(std::time::Duration::from_millis(
+                duration.as_millis(),
+            )),
+        }
     }
 }
 
@@ -111,14 +152,15 @@ impl Timer<super::EmbassyRuntime> for EmbassyTimer {
         embassy_time::Timer::after(duration).await
     }
 
-    async fn run_with_timeout<F: core::future::Future>(
+    fn run_with_timeout<F: core::future::Future>(
         &self,
         duration: Duration,
         future: F,
-    ) -> Result<F::Output, TimeoutError> {
-        embassy_time::with_timeout(duration, future)
-            .await
-            .map_err(|_: embassy_time::TimeoutError| TimeoutError)
+    ) -> impl core::future::Future<Output = Result<F::Output, TimeoutError>> {
+        TimeoutFuture {
+            future,
+            timeout_future: embassy_time::Timer::after(duration),
+        }
     }
 }
 


### PR DESCRIPTION
Partially inspired by the select future optimization by @Ddystopia in PR #115, partially based on my own future/stack size investigations. This PR includes two optimizations which I found to significantly reduce the size of the `picoserve::serve` future.

The first change eliminates the duplication of the future passed into `run_with_timer` caused by the `future` argument being captured as an argument of `run_with_timer` and by the inner figure returned by the runtime timeout async function. The duplication is eliminated by making `run_with_timer` a non-async function which returns a custom TimeoutFuture that implements it's own polling/result logic.

The second change is slightly more subtle. The serving loop in `serve_and_shutdown` after calling awaiting on `read_reuqest_timeout`/`request_reader.read` there is a match block on the result where each arm of the match contains a large amount of async code with several large futures. It appears that the compiler cannot identify that only one arm of the match will be active at a time, so independent space is allocated for the variables in each arm.

This change forces the compiler to alias these variables by encapsulating them into explicit futures that are stored in an `futures::Either` enum. By storing the futures in an enum the compiler is forced to alias the storage of these futures.

Between these two changes I was able to shave 1.2kb, about 25%, off the size of my `picoserve::serve` future.