### PR TITLE
Add Response::with_content_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Several write operations now write directly to the socket's transmit buffer, no longer requiring a local buffer, and thus improving both time and space efficiency.
 
+### Added
+
+- [`Response::with_content_type`](https://docs.rs/picoserve/latest/picoserve/response/struct.Response.html), which overrides the `Content-Type` derived from the body without appending a second header.
+
 ### Fixed
 
 - Future combinators no longer store two copies of the future, greatly reducing memory usage.

--- a/picoserve/src/response.rs
+++ b/picoserve/src/response.rs
@@ -518,6 +518,36 @@ impl<C: Content> Response<ContentHeaders, ContentBody<C>> {
     pub fn ok(body: C) -> Self {
         Self::new(StatusCode::OK, body)
     }
+
+    /// Return a new response with the given `Content-Type`, overriding the value
+    /// derived from the body.
+    ///
+    /// [`Content`] implementations report a fixed content type, so a body holding
+    /// JSON in a string is reported as `text/plain; charset=utf-8`. Supplying the
+    /// correct type via [`with_header`](Response::with_header) does not help,
+    /// because headers are appended rather than replaced, so the response would
+    /// carry two `Content-Type` headers.
+    ///
+    /// ```
+    /// # use picoserve::response::Response;
+    /// let response = Response::ok("{}").with_content_type("application/json");
+    /// ```
+    pub fn with_content_type(self, content_type: &'static str) -> Self {
+        let Self {
+            status_code,
+            headers,
+            body,
+        } = self;
+
+        Self {
+            status_code,
+            headers: ContentHeaders {
+                content_type,
+                ..headers
+            },
+            body,
+        }
+    }
 }
 
 impl Response<NoHeaders, NoBody> {
@@ -774,4 +804,77 @@ impl IntoResponse for Redirect {
 pub trait ErrorWithStatusCode: fmt::Display + IntoResponse {
     /// The [`StatusCode`] to return for this error.
     fn status_code(&self) -> StatusCode;
+}
+
+#[cfg(test)]
+mod tests {
+    use futures_util::FutureExt;
+
+    use super::{ForEachHeader, HeadersIter, Response};
+
+    /// Collects every emitted header into `(name, value)` pairs.
+    struct CollectHeaders(alloc::vec::Vec<(alloc::string::String, alloc::string::String)>);
+
+    impl ForEachHeader for CollectHeaders {
+        type Output = alloc::vec::Vec<(alloc::string::String, alloc::string::String)>;
+        type Error = core::convert::Infallible;
+
+        async fn call<Value: core::fmt::Display>(
+            &mut self,
+            name: &str,
+            value: Value,
+        ) -> Result<(), Self::Error> {
+            self.0.push((
+                alloc::string::ToString::to_string(&name),
+                alloc::string::ToString::to_string(&value),
+            ));
+            Ok(())
+        }
+
+        async fn finalize(self) -> Result<Self::Output, Self::Error> {
+            Ok(self.0)
+        }
+    }
+
+    fn headers_of<H: HeadersIter>(
+        headers: H,
+    ) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String)> {
+        headers
+            .for_each_header(CollectHeaders(alloc::vec::Vec::new()))
+            .now_or_never()
+            .expect("Future must resolve")
+            .expect("Collecting headers is infallible")
+    }
+
+    #[test]
+    #[ntest::timeout(1000)]
+    fn content_type_is_derived_from_the_body_by_default() {
+        let headers = headers_of(Response::ok("{}").headers);
+
+        let content_types = headers
+            .iter()
+            .filter(|(name, _)| name == "Content-Type")
+            .map(|(_, value)| value.as_str())
+            .collect::<alloc::vec::Vec<_>>();
+
+        assert_eq!(content_types, ["text/plain; charset=utf-8"]);
+    }
+
+    #[test]
+    #[ntest::timeout(1000)]
+    fn with_content_type_replaces_the_derived_value() {
+        let headers = headers_of(
+            Response::ok("{}")
+                .with_content_type("application/json")
+                .headers,
+        );
+
+        let content_types = headers
+            .iter()
+            .filter(|(name, _)| name == "Content-Type")
+            .map(|(_, value)| value.as_str())
+            .collect::<alloc::vec::Vec<_>>();
+
+        assert_eq!(content_types, ["application/json"]);
+    }
 }


### PR DESCRIPTION
`Content` implementations report a fixed content type, so a body holding JSON in a string is reported as `text/plain; charset=utf-8`. Supplying the correct type via `with_header` does not help, because headers are appended rather than replaced, so the response ends up carrying two `Content-Type` headers:

```
Content-Type: text/plain; charset=utf-8
Content-Type: application/json
```

`ContentHeaders.content_type` is private, so there is currently no way to override the derived value in place.

## The existing workaround, and why it is expensive on `no_std`

Implementing `Content` on a wrapper type works and is clearly the intended design. On a hosted target it costs nothing.

On an embedded target it is not free. Wrapping splits `Response<String>` into an additional `Response<Wrapper>`, forcing fresh monomorphisations of the response-writing machinery alongside the existing ones. In a `no_std` ESP32 firmware I measured **+3,358 bytes** for two such wrappers, `JsonBody(String)` and `HtmlBody(&'static str)`, replacing 14 manual header additions. That firmware sits at 98.5% of its OTA partition, so the wrapper approach was reverted and the duplicate headers were left in place.

That is the motivation for an in-place override: it is a code-size concern specific to `no_std` consumers.

## This change

`with_content_type` mirrors `with_status_code`: it takes `self` by value and rewrites one field of the existing `ContentHeaders`, so it introduces **no new types** and no additional monomorphisation.

```rust
let response = Response::ok("{}").with_content_type("application/json");
```

`with_header` and `with_headers` semantics are deliberately unchanged. Appending is correct for repeatable headers such as `Set-Cookie`, and changing it would be a breaking change.

## Tests

Two tests in a new `mod tests` in `response.rs`, following the existing `now_or_never` plus `ntest::timeout` convention used in `futures.rs`:

- `content_type_is_derived_from_the_body_by_default` asserts the current behaviour is preserved.
- `with_content_type_replaces_the_derived_value` asserts exactly one `Content-Type` is emitted, with the overridden value.

The second fails if the override is removed, verified by neutering the method body and re-running:

```
left:  ["text/plain; charset=utf-8"]
right: ["application/json"]
```

`cargo test -p picoserve --lib` passes 29 out of 29, `cargo fmt --all --check` is clean, `cargo clippy -p picoserve --lib --all-targets` introduces no new warnings (the pre-existing `BorrowedBuffer` unused import is present on an unmodified tree), and the doctest compiles.

One caveat on my verification: I could not run `cargo test --all-features` locally, because `defmt` fails to link under MSVC on Windows. That job passes in CI on ubuntu, and this change does not touch anything feature-gated.

A `CHANGELOG.md` entry is included under `Unreleased` / `Added`.
